### PR TITLE
Fix AttributeError in coordinator.py

### DIFF
--- a/custom_components/aquarea/coordinator.py
+++ b/custom_components/aquarea/coordinator.py
@@ -60,7 +60,7 @@ class AquareaDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_request_refresh(self, force_fetch: bool = False) -> None:
         """Request a refresh of the data."""
-        _LOGGER.debug("async_request_refresh called for device %s", self.device.device_id)
+        _LOGGER.debug("async_request_refresh called for device %s", self._device_info.device_id)
         if force_fetch:
             self._device = None
         await super().async_request_refresh()


### PR DESCRIPTION
Device may not be available when `async_request_refresh` is called and it results with the following error:

```
Traceback (most recent call last):
  File "/config/custom_components/aquarea/coordinator.py", line 63, in async_request_refresh
    _LOGGER.debug("async_request_refresh called for device %s", self.device.device_id)
                                                                ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'device_id'
```