### PR TITLE
Fix coordinator returning None on transient auth errors

### DIFF
--- a/custom_components/aquarea/coordinator.py
+++ b/custom_components/aquarea/coordinator.py
@@ -177,6 +177,8 @@ class AquareaDataUpdateCoordinator(DataUpdateCoordinator):
                 aioaquarea.AuthenticationErrorCodes.INVALID_CREDENTIALS,
             ):
                 raise ConfigEntryAuthFailed from err
+            else:
+                raise UpdateFailed(f"Authentication error: {err}") from err
         except aioaquarea.errors.RequestFailedError as err:
             raise UpdateFailed(
                 f"Error communicating with Aquarea Smart Cloud API: {err}"


### PR DESCRIPTION
When an AuthenticationError has an error_code other than INVALID_USERNAME_OR_PASSWORD or INVALID_CREDENTIALS, the except block fell through silently. The coordinator returned None, and every entity dereferencing coordinator.device crashed with AttributeError.

Raise UpdateFailed for non-credential auth errors so HA handles it as a transient update failure instead.