### PR TITLE
Remove redundant startup refresh burst

### DIFF
--- a/custom_components/aquarea/__init__.py
+++ b/custom_components/aquarea/__init__.py
@@ -62,14 +62,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         _LOGGER.debug("Forwarding entry setups for platforms")
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-        # Trigger an immediate refresh for all coordinators to ensure entities have data
-        # async_config_entry_first_refresh already did one, but some entities might need
-        # a follow-up if they were registered after the first refresh.
-        # We use a small delay or staggered approach if there are many devices,
-        # but for now we just remove the redundant state write burst.
-        for coordinator in hass.data[DOMAIN][entry.entry_id][DEVICES].values():
-            hass.async_create_task(coordinator.async_refresh())
     except aioaquarea.AuthenticationError as err:
         if err.error_code in (
             aioaquarea.AuthenticationErrorCodes.INVALID_USERNAME_OR_PASSWORD,


### PR DESCRIPTION
async_config_entry_first_refresh already performs the initial fetch per device. The trailing async_refresh loop fired a second full API fetch (device state + monthly consumption) per device on every HA start and reload, doubling the Panasonic Cloud API load and increasing risk of IP throttling.

Delete the redundant loop.