### PR TITLE
Add zone cycles today sensor

### DIFF
--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -136,6 +136,14 @@ def _is_heating_water(device: aioaquarea.Device) -> bool:
     return name == "WATER" if name is not None else str(direction) == "WATER"
 
 
+def _is_heating_zone(device: aioaquarea.Device) -> bool:
+    direction = getattr(device, "current_direction", None)
+    if direction is None:
+        return False
+    name = getattr(direction, "name", None)
+    return name == "PUMP" if name is not None else str(direction) == "PUMP"
+
+
 def _is_defrosting(device: aioaquarea.Device) -> bool:
     return device.device_mode_status is aioaquarea.DeviceModeStatus.DEFROST
 
@@ -155,6 +163,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             translation_key="dhw_cycles_today",
             icon="mdi:water-boiler",
             detector=_is_heating_water,
+        ))
+        entities.append(DailyEdgeCounterSensor(
+            coordinator,
+            unique_suffix="heating_cycles_today",
+            translation_key="heating_cycles_today",
+            icon="mdi:radiator",
+            detector=_is_heating_zone,
         ))
         entities.append(DailyEdgeCounterSensor(
             coordinator,

--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -136,7 +136,7 @@ def _is_heating_water(device: aioaquarea.Device) -> bool:
     return name == "WATER" if name is not None else str(direction) == "WATER"
 
 
-def _is_heating_zone(device: aioaquarea.Device) -> bool:
+def _is_zone_active(device: aioaquarea.Device) -> bool:
     direction = getattr(device, "current_direction", None)
     if direction is None:
         return False
@@ -166,10 +166,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         ))
         entities.append(DailyEdgeCounterSensor(
             coordinator,
-            unique_suffix="heating_cycles_today",
-            translation_key="heating_cycles_today",
+            unique_suffix="zone_cycles_today",
+            translation_key="zone_cycles_today",
             icon="mdi:radiator",
-            detector=_is_heating_zone,
+            detector=_is_zone_active,
         ))
         entities.append(DailyEdgeCounterSensor(
             coordinator,

--- a/custom_components/aquarea/translations/en.json
+++ b/custom_components/aquarea/translations/en.json
@@ -92,6 +92,9 @@
         "dhw_cycles_today": {
           "name": "DHW heating cycles today"
         },
+        "heating_cycles_today": {
+          "name": "Heating cycles today"
+        },
         "defrost_cycles_today": {
           "name": "Defrost cycles today"
         }

--- a/custom_components/aquarea/translations/en.json
+++ b/custom_components/aquarea/translations/en.json
@@ -92,8 +92,8 @@
         "dhw_cycles_today": {
           "name": "DHW heating cycles today"
         },
-        "heating_cycles_today": {
-          "name": "Heating cycles today"
+        "zone_cycles_today": {
+          "name": "Zone cycles today"
         },
         "defrost_cycles_today": {
           "name": "Defrost cycles today"


### PR DESCRIPTION
## Summary

Adds a `zone_cycles_today` sensor that mirrors the `dhw_cycles_today` and `defrost_cycles_today` counters introduced in v1.0.53. It increments each time the heat pump engages the zone (space-heating/cooling) circuit — detected as a transition of `current_direction` into `DeviceDirection.PUMP` — and resets at local midnight.

Implementation reuses the existing `DailyEdgeCounterSensor`: only a new detector (`_is_zone_active`), one extra `entities.append(...)` registration, and one translation key.

## Why

Cycle count per day is one of the most useful operational metrics for a heat pump:

- A sudden jump (e.g. 6 → 25 cycles/day) is a strong early-warning signal for short-cycling caused by misconfigured hysteresis, undersized buffer, valve fault, or sensor drift.
- It's a much earlier signal than kWh — energy creeps up slowly, but cycle count jumps the moment something starts thrashing.
- Completes the picture: with DHW + defrost + zone cycles, you can see total daily compressor activity at a glance and break it down by purpose.

## Definition

A zone cycle starts on a low→high transition of `current_direction.name == "PUMP"`. This is the same direction signal that `climate.py` uses to derive `HVACAction.HEATING` / `HVACAction.COOLING`, so the counter is HVAC-mode-agnostic by design — it counts all zone-circuit engagements regardless of whether the device is heating or cooling. A single device-level event — doesn't depend on zone count and doesn't double-count when both zones call simultaneously.

## Files changed

- `custom_components/aquarea/sensor.py` — new `_is_zone_active` detector + new `DailyEdgeCounterSensor` registration (icon: `mdi:radiator`)
- `custom_components/aquarea/translations/en.json` — `zone_cycles_today` translation key

## Test plan

- [ ] Install on a running Aquarea instance, confirm `sensor.<device>_zone_cycles_today` appears
- [ ] Trigger a heating call, confirm value increments by exactly 1 per cycle
- [ ] On a cool-capable unit, trigger a cooling call, confirm value also increments
- [ ] Confirm value resets at local midnight
- [ ] Confirm value survives HA restart (RestoreEntity already handles this in `DailyEdgeCounterSensor`)
- [ ] Confirm DHW-only and defrost-only events do **not** increment this counter