### PR TITLE
Fix zone_cycles_today miscounting DHW cycles

### DIFF
--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -137,11 +137,22 @@ def _is_heating_water(device: aioaquarea.Device) -> bool:
 
 
 def _is_zone_active(device: aioaquarea.Device) -> bool:
+    # DeviceDirection.PUMP is reported not only for space heating/cooling but
+    # also transiently while the tank is being heated, so a PUMP reading on its
+    # own would miscount DHW activity as zone cycles. Only count it when at
+    # least one zone is actually switched on.
     direction = getattr(device, "current_direction", None)
     if direction is None:
         return False
     name = getattr(direction, "name", None)
-    return name == "PUMP" if name is not None else str(direction) == "PUMP"
+    is_pump = name == "PUMP" if name is not None else str(direction) == "PUMP"
+    if not is_pump:
+        return False
+    zones = getattr(device, "zones", None) or {}
+    return any(
+        zone.operation_status == aioaquarea.OperationStatus.ON
+        for zone in zones.values()
+    )
 
 
 def _is_defrosting(device: aioaquarea.Device) -> bool:

--- a/tests/test_zone_detector.py
+++ b/tests/test_zone_detector.py
@@ -1,0 +1,107 @@
+"""Regression test for the zone-cycle detector (_is_zone_active).
+
+Background
+----------
+`zone_cycles_today` increments on each low->high transition of
+`_is_zone_active`. The first version keyed purely off `current_direction ==
+PUMP`, but on real hardware the device also reports `PUMP` transiently while
+heating the DHW tank, so the counter tracked `dhw_cycles_today` in lockstep
+even with every zone switched off. The fix additionally requires that at
+least one zone be `operation_status == ON`.
+
+This test loads the *actual* `_is_zone_active` out of sensor.py (via AST, so
+it exercises the shipped code rather than a copy) and runs it against stub
+enums whose values mirror aioaquarea.data:
+
+    OperationStatus:  OFF=0, ON=1
+    DeviceDirection:  IDLE=0, PUMP=1, WATER=2
+
+It is intentionally dependency-free (stdlib only) so it runs without Home
+Assistant, aioaquarea, or pytest installed:
+
+    python3 tests/test_zone_detector.py
+"""
+import ast
+import os
+import sys
+import types
+from enum import IntEnum
+
+SENSOR = os.path.join(
+    os.path.dirname(__file__),
+    "..", "custom_components", "aquarea", "sensor.py",
+)
+
+
+# --- stub aioaquarea module (only what the detector touches) -----------------
+class OperationStatus(IntEnum):
+    OFF = 0
+    ON = 1
+
+
+class DeviceDirection(IntEnum):
+    IDLE = 0
+    PUMP = 1
+    WATER = 2
+
+
+aioaquarea = types.ModuleType("aioaquarea")
+aioaquarea.OperationStatus = OperationStatus
+aioaquarea.DeviceDirection = DeviceDirection
+aioaquarea.Device = object  # only referenced as a type annotation
+sys.modules["aioaquarea"] = aioaquarea
+
+
+# --- pull the real _is_zone_active out of sensor.py -------------------------
+def _load_detector():
+    with open(SENSOR) as fh:
+        tree = ast.parse(fh.read())
+    node = next(
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_is_zone_active"
+    )
+    namespace = {"aioaquarea": aioaquarea}
+    exec(compile(ast.Module([node], []), SENSOR, "exec"), namespace)
+    return namespace["_is_zone_active"]
+
+
+# --- fakes -------------------------------------------------------------------
+class _Zone:
+    def __init__(self, on):
+        self.operation_status = OperationStatus.ON if on else OperationStatus.OFF
+
+
+class _Device:
+    def __init__(self, direction, zones):
+        self.current_direction = direction
+        self.zones = zones
+
+
+def main():
+    is_zone_active = _load_detector()
+    D = DeviceDirection
+    cases = [
+        # (name, device, expected)
+        ("idle, no zones on",            _Device(D.IDLE,  {0: _Zone(False)}),                 False),
+        ("DHW heating (WATER)",          _Device(D.WATER, {0: _Zone(False)}),                 False),
+        ("PUMP, all zones OFF (DHW)",    _Device(D.PUMP,  {0: _Zone(False), 1: _Zone(False)}), False),
+        ("PUMP, one zone ON",            _Device(D.PUMP,  {0: _Zone(False), 1: _Zone(True)}),  True),
+        ("PUMP, all zones ON",           _Device(D.PUMP,  {0: _Zone(True)}),                  True),
+        ("PUMP, no zones dict",          _Device(D.PUMP,  None),                              False),
+        ("direction is None",            _Device(None,    {0: _Zone(True)}),                  False),
+    ]
+
+    failures = 0
+    for name, dev, expected in cases:
+        got = is_zone_active(dev)
+        ok = got == expected
+        failures += not ok
+        print(f"[{'PASS' if ok else 'FAIL'}] {name:<28} expected={expected!s:<5} got={got}")
+
+    print()
+    print("ALL PASSED" if not failures else f"{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #30 (merged in v1.0.54). Field-testing the new `zone_cycles_today` sensor revealed it over-counts.

## Symptom

With **both zones off**, `zone_cycles_today` still climbed — tracking `dhw_cycles_today` almost 1:1 throughout the day:

| | |
|---|---|
| Zone cycles today | climbs 4→8 over the day, zones off the whole time |
| DHW heating cycles today | climbs 3→7 over the same period |

## Cause

`DeviceDirection` is a 3-value `IntEnum` — `IDLE=0, PUMP=1, WATER=2`. On real hardware the device transiently reports `PUMP` *during DHW heating* (compressor/circulation engaged) before/around diverting to `WATER` for the tank — `PUMP` is not exclusive to space heating/cooling. So the merged `direction == "PUMP"` detector counted every tank-heating cycle as a zone cycle.

`current_action` doesn't disambiguate either: during that transient, `direction == PUMP` + `mode == HEAT` resolves to `DeviceAction.HEATING`, not `HEATING_WATER`.

## Fix

Only count a `PUMP` reading as a zone cycle when at least one zone is actually switched on:

```python
zones = getattr(device, "zones", None) or {}
return any(
    zone.operation_status == aioaquarea.OperationStatus.ON
    for zone in zones.values()
)
```

With all zones off, DHW-only activity no longer increments the counter.

**Known minor limitation:** if a zone is enabled *and* a DHW cycle runs, the DHW transient could still tick the counter — a much narrower case than the all-zones-off miscount this fixes. Happy to tighten further if you'd prefer a different signal (e.g. per-zone action if the API later exposes it).

## Test plan

- [x] `py_compile` passes
- [ ] All zones off + DHW cycles → `zone_cycles_today` stays flat
- [ ] A zone on + heating call → increments by 1 per cycle
- [ ] Cooling call on a cool-capable unit → also increments