### PR TITLE
Clarify invalid_auth error: Comfort Cloud account required, not Aquarea Home app

### DIFF
--- a/custom_components/aquarea/strings.json
+++ b/custom_components/aquarea/strings.json
@@ -12,7 +12,7 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_auth": "Invalid username or password. Note: this integration uses your Panasonic Comfort Cloud account (the same login as the Comfort Cloud app) — not the separate Aquarea Smart Cloud / Aquarea Home app account.",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "api_error": "API error: {api_error_msg}"
     },

--- a/custom_components/aquarea/translations/en.json
+++ b/custom_components/aquarea/translations/en.json
@@ -5,7 +5,7 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid username or password",
+            "invalid_auth": "Invalid username or password. Note: this integration uses your Panasonic Comfort Cloud account (the same login as the Comfort Cloud app) — not the separate Aquarea Smart Cloud / Aquarea Home app account.",
             "unknown": "Unexpected error",
             "api_error": "API error: {api_error_msg}"
         },


### PR DESCRIPTION
Addresses #35.

Several users reported login failures (`invalid_user_password`, HTTP 401) despite confirming their password works fine in a Panasonic mobile app. As identified by @BuonBreda in the issue thread, the root cause in most of these reports is credential confusion between two separate Panasonic backends:

- **Panasonic Comfort Cloud** (official Panasonic backend) — what this integration authenticates against.
- **Aquarea Home** app (Solution Tech) — a different app/account, whose credentials will not work here.

The old `invalid_auth` message ("Invalid username or password") gave no hint about this, so users kept retrying the same (wrong-backend) credentials. This PR only reworks that error string in `strings.json` and `translations/en.json` to explicitly name the Comfort Cloud account requirement — no logic changes, since the two credential systems can't be told apart from the API response alone.

Happy to extend this to the other translation files or the README if that's preferred instead of/alongside the error string.
