### PR TITLE
Fix options flow TypeError: stop passing config_entry to the handler

### DIFF
--- a/custom_components/aquarea/config_flow.py
+++ b/custom_components/aquarea/config_flow.py
@@ -57,7 +57,7 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> AquareaOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return AquareaOptionsFlowHandler(config_entry)
+        return AquareaOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
Fixes #39. Possibly also the unresolved symptom in #34.

One-line fix: `async_get_options_flow` still passed `config_entry` to `AquareaOptionsFlowHandler`, but Home Assistant removed the `OptionsFlow.__init__(config_entry)` signature — the flow manager now injects `config_entry` as a property on the instance. Since the handler declares no `__init__`, the call raised:

```
TypeError: AquareaOptionsFlowHandler() takes no arguments
```

which made the **Configure** dialog unopenable (UI shows "Config flow could not be loaded: 500 Internal Server Error") — `consumption_interval` could not be changed from the UI.

`async_step_init` already uses the injected `self.config_entry`, so dropping the argument is the complete fix. The `config_entry` parameter on `async_get_options_flow` itself stays, as that signature is dictated by Home Assistant.

Written with AI assistance (Claude Code), as with #37; the change was verified against the live traceback and current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
