### PR TITLE
Fix static type errors that need no behaviour changes

### DIFF
--- a/custom_components/aquarea/__init__.py
+++ b/custom_components/aquarea/__init__.py
@@ -131,7 +131,3 @@ class AquareaBaseEntity(CoordinatorEntity[AquareaDataUpdateCoordinator]):
         """Handle updated data from the coordinator."""
         self.async_write_ha_state()
 
-    @callback
-    def async_write_ha_state(self) -> None:
-        """Write the state to Home Assistant."""
-        super().async_write_ha_state()

--- a/custom_components/aquarea/config_flow.py
+++ b/custom_components/aquarea/config_flow.py
@@ -10,8 +10,8 @@ import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
@@ -61,7 +61,7 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         errors = {}
         if user_input is not None:
@@ -103,7 +103,7 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_show_reauth_form(self._username, errors)
 
-    async def async_complete_reauth(self, username: str, password: str) -> FlowResult:
+    async def async_complete_reauth(self, username: str, password: str) -> ConfigFlowResult:
         """Complete reauth."""
         entry = await self.async_set_unique_id(self.unique_id)
         assert entry
@@ -119,7 +119,7 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_show_reauth_form(
         self, username: str, errors: dict[str, str] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Show the reauth form."""
         return self.async_show_form(
             step_id="reauth",
@@ -178,7 +178,7 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] | None = None,
         description_placeholders: dict[str, str] | None = None,
         last_step: bool | None = None,
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Show the form with dynamic error message if needed."""
         if errors and errors.get("base") == "api_error":
             if description_placeholders is None:
@@ -201,7 +201,7 @@ class AquareaOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -28,7 +28,7 @@ from .coordinator import AquareaDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class AquareaEnergyConsumptionSensorDescription(SensorEntityDescription):
     consumption_type: aioaquarea.ConsumptionType
     exists_fn: Callable[[AquareaDataUpdateCoordinator], bool] = lambda _: True

--- a/custom_components/aquarea/switch.py
+++ b/custom_components/aquarea/switch.py
@@ -1,6 +1,7 @@
 """Aquarea Switch Sensors."""
 import asyncio
 import logging
+from typing import Any
 
 import aioaquarea
 
@@ -75,14 +76,14 @@ class AquareaForceDHWSwitch(AquareaBaseEntity, SwitchEntity):
                 getattr(self.coordinator.device, "device_id", "unknown"),
             )
 
-    async def async_turn_on(self) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on Force DHW."""
         self._optimistic_is_on = True
         self.async_write_ha_state()
         await self.coordinator.device.set_force_dhw(aioaquarea.ForceDHW.ON)
         self.hass.async_create_task(self._schedule_refresh(SWITCH_DELAY))
 
-    async def async_turn_off(self) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off Force DHW."""
         self._optimistic_is_on = False
         self.async_write_ha_state()
@@ -125,14 +126,14 @@ class AquareaForceHeaterSwitch(AquareaBaseEntity, SwitchEntity):
                 getattr(self.coordinator.device, "device_id", "unknown"),
             )
 
-    async def async_turn_on(self) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on Force heater."""
         self._optimistic_is_on = True
         self.async_write_ha_state()
         await self.coordinator.device.set_force_heater(aioaquarea.ForceHeater.ON)
         self.hass.async_create_task(self._schedule_refresh(SWITCH_DELAY))
 
-    async def async_turn_off(self) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off Force heater."""
         self._optimistic_is_on = False
         self.async_write_ha_state()
@@ -174,14 +175,14 @@ class AquareaHolidayTimerSwitch(AquareaBaseEntity, SwitchEntity):
                 getattr(self.coordinator.device, "device_id", "unknown"),
             )
 
-    async def async_turn_on(self) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on Holiday Timer."""
         self._optimistic_is_on = True
         self.async_write_ha_state()
         await self.coordinator.device.set_holiday_timer(aioaquarea.HolidayTimer.ON)
         self.hass.async_create_task(self._schedule_refresh(SWITCH_DELAY))
 
-    async def async_turn_off(self) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off Holiday Timer."""
         self._optimistic_is_on = False
         self.async_write_ha_state()


### PR DESCRIPTION

Groundwork for #42 (adding mypy to CI): the part of the existing type debt that can be fixed
without deciding anything about behaviour.

Running `mypy custom_components/aquarea` with mypy 2.3.1 against homeassistant 2026.9.1 goes from
**32 errors to 18** with these 14 changed lines. Nothing here alters what the integration does at
runtime.

| Change | File | Errors cleared |
|---|---|---:|
| `homeassistant.data_entry_flow.FlowResult` → `homeassistant.config_entries.ConfigFlowResult` | `config_flow.py` | 6 |
| `**kwargs: Any` on the three `async_turn_on`/`async_turn_off` pairs | `switch.py` | 6 |
| `@dataclass(frozen=True, kw_only=True)` on the entity description | `sensor.py` | 1 |
| Drop the `async_write_ha_state` override | `__init__.py` | 1 |

Why each one:

- **`ConfigFlowResult`** — `ConfigFlow` declares its steps as returning `ConfigFlowResult`;
  `FlowResult` is the generic base. Every annotated step was an incompatible override and every
  `return self.async_show_form(...)` an incompatible return value.
- **`**kwargs: Any`** — `ToggleEntity` declares `async_turn_on(self, **kwargs: Any)`. Home
  Assistant calls through the base signature, so the narrower override is also a latent
  `TypeError` if a caller ever passes a keyword argument.
- **`frozen=True`** — `SensorEntityDescription` is a frozen dataclass; a non-frozen subclass of it
  is rejected by `dataclasses` on stricter runtimes. Every entity description in core is frozen.
- **`async_write_ha_state`** — the override's body was just `super().async_write_ha_state()`, and
  `Entity` marks that method `@final`. Dead code.

Verification:

- `mypy custom_components/aquarea` → `Found 18 errors in 6 files (checked 11 source files)`,
  down from 32 in 8 files
- `python3 tests/test_setup_entry_errors.py` → ALL PASSED
- `python3 tests/test_zone_detector.py` → ALL PASSED

One thing worth flagging: `ConfigFlowResult` needs Home Assistant 2024.4, while `hacs.json`
declares a floor of 2024.2.0. That floor is already inaccurate — the options flow merged in #40
relies on the framework-supplied `OptionsFlow.config_entry` property from HA 2024.11 — but if you
would rather settle the declared minimum first, say so and I will drop that hunk and leave those 6
errors for the baseline in #42.
