### PR TITLE
Add mypy to CI with a baseline for the known errors

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,0 +1,21 @@
+name: Type check with mypy
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  mypy:
+    name: mypy
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.14"
+          cache: "pip"
+          cache-dependency-path: "requirements_typing.txt"
+      - name: Install Home Assistant and mypy
+        run: pip install -r requirements_typing.txt
+      - name: Run mypy
+        run: mypy custom_components/aquarea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,24 @@ A Home Assistant custom integration for Panasonic Aquarea heat pumps. It consist
 ## Commands
 
 ### CI Validation
-The two GitHub Actions workflows validate:
+The GitHub Actions workflows validate:
 - **hassfest** (`.github/workflows/hassfest.yaml`) — HA integration correctness
 - **HACS** (`.github/workflows/hacs.yaml`) — HACS compatibility
+- **mypy** (`.github/workflows/mypy.yaml`) — static type checking of
+  `custom_components/aquarea` against the Home Assistant version pinned in
+  `requirements_typing.txt`
 
-There is no automated test suite.
+```bash
+pip install -r requirements_typing.txt
+mypy custom_components/aquarea
+```
+
+Known type errors are silenced with inline `# type: ignore[code]  # reason`
+comments so the gate stays green while the underlying issues are fixed one at a
+time; `warn_unused_ignores` reports any that become unnecessary.
+
+The two files in `tests/` are stdlib-only and run directly
+(`python3 tests/test_setup_entry_errors.py`), but no workflow executes them.
 
 ### Installing the library for Development
 ```bash
@@ -75,8 +88,9 @@ All entities extend HA base classes and `CoordinatorEntity`. After sending a com
 | `button.py` | One-shot actions (refresh, force DHW, defrost) |
 
 ### Minimum Requirements
-- Home Assistant 2024.2.0+
-- Python 3.9+
+- Home Assistant 2024.12.0+ — the options flow relies on the framework-supplied
+  `OptionsFlow.config_entry` property, added in 2024.12
+- Python 3.12+ (required by Home Assistant 2024.12)
 
 ## Key Constraints
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A possible solution to this behaviour is to create a second account specifically
 Now it should be possible to access the aquarea smart cloud website and also use the home assistant integration at the same time.
 
 ### Minimum Home Assistant version required
-The minimum supported version of Home Assistant is **2024.2**
+The minimum supported version of Home Assistant is **2024.12**
 
 ## Installation
 

--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -271,7 +271,8 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
         Schedule a single delayed refresh after applying the preset so the
         coordinator fetches the resulting state once it's available.
         """
-        if preset_mode not in self.preset_modes:
+        # preset_modes may be None
+        if preset_mode not in self.preset_modes:  # type: ignore[operator]
             raise ValueError(f"Unsupported preset mode: {preset_mode}")
         _LOGGER.debug(
             "Setting preset mode of device %s to %s",

--- a/custom_components/aquarea/config_flow.py
+++ b/custom_components/aquarea/config_flow.py
@@ -137,15 +137,18 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._username = entry_data[CONF_USERNAME]
             return self._username
 
-        if self.context.init_data and self.context.init_data.get(CONF_USERNAME):
-            self._username = self.context.init_data[CONF_USERNAME]
+        # init_data is not declared on ConfigFlowContext
+        init_data = self.context.init_data  # type: ignore[attr-defined]
+        if init_data and init_data.get(CONF_USERNAME):
+            self._username = init_data[CONF_USERNAME]
             return self._username
 
         if self.unique_id:
             self._username = self.unique_id
             return self._username
 
-        return None
+        # returns None when no username is known
+        return None  # type: ignore[return-value]
 
     async def _validate_input(self, username, password) -> dict[str, str]:
         """Validate the user input allows us to connect."""
@@ -161,7 +164,8 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except aioaquarea.errors.ApiError as err:
             _LOGGER.error("API error during setup: %s", err)
             errors["base"] = "api_error"
-            self.context["api_error_msg"] = str(err)
+            # api_error_msg is not a ConfigFlowContext key
+            self.context["api_error_msg"] = str(err)  # type: ignore[typeddict-unknown-key]
         except aioaquarea.errors.RequestFailedError:
             errors["base"] = "cannot_connect"
         except Exception:  # pylint: disable=broad-except
@@ -170,7 +174,8 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return errors
 
-    def async_show_form(
+    # override is narrower than the base signature
+    def async_show_form(  # type: ignore[override]
         self,
         *,
         step_id: str,
@@ -183,9 +188,9 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if errors and errors.get("base") == "api_error":
             if description_placeholders is None:
                 description_placeholders = {}
-            description_placeholders["api_error_msg"] = self.context.get(
-                "api_error_msg", "Unknown API error"
-            )
+            msg = self.context.get("api_error_msg", "Unknown API error")
+            # context.get() returns object
+            description_placeholders["api_error_msg"] = msg  # type: ignore[assignment]
 
         return super().async_show_form(
             step_id=step_id,

--- a/custom_components/aquarea/coordinator.py
+++ b/custom_components/aquarea/coordinator.py
@@ -86,7 +86,8 @@ class AquareaDataUpdateCoordinator(DataUpdateCoordinator):
         """Return the last cached month consumption entries or None."""
         return getattr(self, "_month_consumption", None)
 
-    async def _async_update_data(self) -> None:
+    # should be DataUpdateCoordinator[None]: state is kept on the coordinator
+    async def _async_update_data(self) -> None:  # type: ignore[override]
         """Fetch data from Aquarea Smart Cloud Service with tiered intervals."""
         try:
             # Ensure we are logged in and token is valid

--- a/custom_components/aquarea/select.py
+++ b/custom_components/aquarea/select.py
@@ -71,7 +71,10 @@ class AquareaQuietModeSelect(AquareaBaseEntity, SelectEntity):
         """The current select option."""
         if self._optimistic_option is not None:
             return self._optimistic_option
-        return QUIET_MODE_REVERSE_LOOKUP.get(self.coordinator.device.quiet_mode)
+        # lookup can miss; should be str | None
+        return QUIET_MODE_REVERSE_LOOKUP.get(  # type: ignore[return-value]
+            self.coordinator.device.quiet_mode
+        )
 
     async def _schedule_refresh(self, delay: float = SELECT_DELAY) -> None:
         """Clear optimistic state and request a coordinator refresh after a short delay."""
@@ -122,7 +125,10 @@ class AquareaPowerfulTimeSelect(AquareaBaseEntity, SelectEntity):
         """The current select option."""
         if self._optimistic_option is not None:
             return self._optimistic_option
-        return POWERFUL_TIME_REVERSE_LOOKUP.get(self.coordinator.device.powerful_time)
+        # lookup can miss; should be str | None
+        return POWERFUL_TIME_REVERSE_LOOKUP.get(  # type: ignore[return-value]
+            self.coordinator.device.powerful_time
+        )
 
     async def _schedule_refresh(self, delay: float = SELECT_DELAY) -> None:
         """Clear optimistic state and request a coordinator refresh after a short delay."""

--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -199,7 +199,8 @@ class AquareaSensorExtraStoredData(SensorExtraStoredData):
 
     @classmethod
     def from_dict(cls, restored: dict[str, Any]) -> Self:
-        sensor_data = super().from_dict(restored)
+        # restored data may be None
+        sensor_data: Self = super().from_dict(restored)  # type: ignore[assignment]
         return cls(
             native_value=sensor_data.native_value,
             native_unit_of_measurement=sensor_data.native_unit_of_measurement,
@@ -462,7 +463,8 @@ class AquareaEdgeCounterExtraStoredData(SensorExtraStoredData):
 
     @classmethod
     def from_dict(cls, restored: dict[str, Any]) -> Self:
-        sensor_data = super().from_dict(restored)
+        # restored data may be None
+        sensor_data: Self = super().from_dict(restored)  # type: ignore[assignment]
         return cls(
             native_value=sensor_data.native_value,
             native_unit_of_measurement=sensor_data.native_unit_of_measurement,
@@ -507,7 +509,11 @@ class DailyEdgeCounterSensor(AquareaBaseEntity, SensorEntity, RestoreEntity):
         restored = await self.async_get_last_sensor_data()
         if restored is not None:
             try:
-                self._attr_native_value = int(restored.native_value) if restored.native_value is not None else 0
+                native = restored.native_value
+                self._attr_native_value = (
+                    # native_value may be a date or Decimal
+                    int(native) if native is not None else 0  # type: ignore[arg-type]
+                )
             except (TypeError, ValueError):
                 self._attr_native_value = 0
             self._attr_last_reset = restored.last_reset

--- a/custom_components/aquarea/water_heater.py
+++ b/custom_components/aquarea/water_heater.py
@@ -86,7 +86,8 @@ class WaterHeater(AquareaBaseEntity, WaterHeaterEntity):
 
     def _update_operation_state(self) -> None:
         if self.coordinator.device.tank.operation_status == OperationStatus.OFF:
-            self._attr_state = STATE_OFF
+            # no-op: the base class declares _attr_state as None
+            self._attr_state = STATE_OFF  # type: ignore[assignment]
             self._attr_current_operation = STATE_OFF
             self._attr_icon = (
                 "mdi:water-boiler-alert"
@@ -97,7 +98,8 @@ class WaterHeater(AquareaBaseEntity, WaterHeaterEntity):
 
         # Device reports tank is on; treat the water heater as a heat pump device.
         self._attr_icon = "mdi:water-boiler"
-        self._attr_state = STATE_HEAT_PUMP
+        # no-op: the base class declares _attr_state as None
+        self._attr_state = STATE_HEAT_PUMP  # type: ignore[assignment]
 
         # Determine if the device is actively heating the tank. Different device actions
         # from the library may be used depending on model/version; check several forms.

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
     "name": "Aquarea Smart Cloud",
     "render_readme": true,
     "content_in_root": false,
-    "homeassistant": "2024.2.0"
+    "homeassistant": "2024.12.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.mypy]
+python_version = "3.14"
+warn_unused_ignores = true
+
+# aioaquarea ships no py.typed marker, so its symbols are untyped for mypy.
+# Scoped to the one module rather than set globally, so a genuinely missing
+# dependency still fails loudly.
+[[tool.mypy.overrides]]
+module = "aioaquarea.*"
+ignore_missing_imports = true

--- a/requirements_typing.txt
+++ b/requirements_typing.txt
@@ -1,0 +1,7 @@
+# Pinned so CI is reproducible: a new Home Assistant release can introduce type
+# errors in unchanged code, and that should arrive as a dependabot PR rather
+# than as a surprise red build. Keep python_version in pyproject.toml and the
+# workflow's python-version in step with the Home Assistant pin.
+homeassistant==2026.9.1
+mypy==2.3.1
+aioaquarea>=1.0.7


### PR DESCRIPTION
Closes #42, taking **option B**: put the gate up now, silence what is already broken, and fix those one at a time.

## What runs

`.github/workflows/mypy.yaml` installs the pinned Home Assistant and runs `mypy custom_components/aquarea` on push and pull_request — about two minutes with the pip cache. On this branch it reports:

```
Success: no issues found in 11 source files
```

Both files in `tests/` still pass (`python3 tests/test_setup_entry_errors.py`, `python3 tests/test_zone_detector.py`).

## Why the pins

`requirements_typing.txt` pins `homeassistant` and `mypy` exactly. A new Home Assistant release can introduce type errors in code that did not change — this tree reports 31 errors against 2026.2.3 and 32 against 2026.9.1 — and that is better arriving as a dependabot bump PR than as a build that goes red on its own. `dependabot.yml` already watches `pip` at the repository root, so it starts producing those once a requirements file exists there.

`pyproject.toml` is deliberately minimal: `mypy custom_components/aquarea` resolves with no package-path options, and the only override is `ignore_missing_imports` for `aioaquarea` (no `py.typed` marker), scoped to that one module so a genuinely missing dependency still fails loudly.

## The baseline

14 sites carry `# type: ignore[code]` with the reason on the line above — inline rather than per-module overrides, so they read as a visible list of work instead of disappearing into config. `warn_unused_ignores` is on, so each one fails the build as soon as its underlying error is fixed.

Four of them mark real defects, each of which I'd like to send as its own PR:

| Site | Defect |
|---|---|
| `climate.py` `async_set_preset_mode` | `preset_mode not in self.preset_modes` raises `TypeError` when `preset_modes` is `None` — same shape as #39 |
| `config_flow.py` `_try_get_username` | annotated `-> str` but returns `None`; reauth then passes `None` into `aioaquarea.Client(...)`. Fixing the annotation alone cascades to two call sites, so it needs a decision about what reauth does with no username |
| `sensor.py` `from_dict` ×2 | `SensorExtraStoredData.from_dict` can return `None`, dereferenced unguarded on the restore path |
| `select.py` `current_option` ×2 | lookup miss returns `None` through a `-> str` annotation |

The `water_heater.py` pair is dead code rather than a defect: `WaterHeaterEntity` declares `_attr_state` as `None` and `state` returns `current_operation`, so those writes have no effect. Two more of them sit in an unannotated function body and are only visible with `--check-untyped-defs`.

## Restructured expressions

Four small changes so an ignore comment fits within a reasonable line length. None change behaviour:

- `config_flow.py` binds `self.context.init_data` and the `context.get()` result to locals
- `sensor.py` annotates the restored local in the two `from_dict` overrides that call Home Assistant's implementation — one ignore instead of four on the attribute accesses (the third `from_dict` inherits from a class that already narrows the type)
- `sensor.py`'s `int()` conversion in `async_added_to_hass` is split across lines; that statement was already 112 characters
- `select.py`'s two lookups are wrapped

## Declared Home Assistant floor

Corrected as agreed in #42. The options flow has required **2024.12** since #40 — it relies on the framework-supplied `OptionsFlow.config_entry` property, which is absent in 2024.11.0 and present in 2024.12.0 (I checked both tags) — and `ConfigFlowResult`, adopted in #43, needs 2024.4. `hacs.json`, `README.md` and `CLAUDE.md` all claimed 2024.2.0 and now say 2024.12.0; `CLAUDE.md`'s Python floor moves to 3.12, which is what Home Assistant 2024.12 requires.

`CLAUDE.md`'s CI section is updated to describe the new workflow and the ignore convention.
