### PR TITLE
Make the preset_mode guard None-safe and drop its type: ignore

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -271,8 +271,8 @@ class HeatPumpClimate(AquareaBaseEntity, ClimateEntity):
         Schedule a single delayed refresh after applying the preset so the
         coordinator fetches the resulting state once it's available.
         """
-        # preset_modes may be None
-        if preset_mode not in self.preset_modes:  # type: ignore[operator]
+        preset_modes = self.preset_modes
+        if preset_modes is None or preset_mode not in preset_modes:
             raise ValueError(f"Unsupported preset mode: {preset_mode}")
         _LOGGER.debug(
             "Setting preset mode of device %s to %s",


### PR DESCRIPTION
First of the follow-ups from #42/#44: removes one `# type: ignore` by fixing what it marks.

```python
-        # preset_modes may be None
-        if preset_mode not in self.preset_modes:  # type: ignore[operator]
+        preset_modes = self.preset_modes
+        if preset_modes is None or preset_mode not in preset_modes:
             raise ValueError(f"Unsupported preset mode: {preset_mode}")
```

`_attr_preset_modes` is only assigned when the device reports `support_special_status`; otherwise it keeps `ClimateEntity`'s default of `None`, and `preset_mode not in None` raises `TypeError: argument of type 'NoneType' is not iterable` instead of the intended `ValueError`.

## Correction to what I claimed in #42

I described this in the issue and in #44's table as a live defect "the same shape as #39". Having read Home Assistant's climate component properly, that overstates it, and the correction belongs here rather than buried:

- `climate.set_preset_mode` is registered with `[ClimateEntityFeature.PRESET_MODE]`, and a device without `support_special_status` never sets that feature bit — the service call is rejected before it reaches the entity.
- Even with the feature set, the service dispatches to `async_handle_set_preset_mode_service`, which calls `_valid_mode_or_raise("preset", preset_mode, self.preset_modes)` first. That helper's test is `if modes and mode in modes`, so a `None` list is already handled and produces a translated `ServiceValidationError`.

So the `TypeError` is not reachable through the service path today. It is reachable only by calling `async_set_preset_mode` directly in-process, which nothing in the integration does. This is worth fixing as defence in depth and to clear the ignore, but it is not the user-facing bug I implied it was.

`async_set_hvac_mode` carries the same redundant check at line 206. It has no type error, because `_attr_hvac_modes` is always assigned in `__init__`, so I have left it alone — happy to remove both checks in a follow-up if you would rather lean on core's validation.

## Verification

- `mypy custom_components/aquarea` → `Success: no issues found in 11 source files`, with the ignore removed (`warn_unused_ignores` would have failed the build if the error had gone away on its own)
- `python3 tests/test_setup_entry_errors.py` and `python3 tests/test_zone_detector.py` → ALL PASSED
