### PR TITLE
Read init_data from the flow handler, not from context

### DIFF
--- a/custom_components/aquarea/config_flow.py
+++ b/custom_components/aquarea/config_flow.py
@@ -137,8 +137,7 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._username = entry_data[CONF_USERNAME]
             return self._username
 
-        # init_data is not declared on ConfigFlowContext
-        init_data = self.context.init_data  # type: ignore[attr-defined]
+        init_data = self.init_data
         if init_data and init_data.get(CONF_USERNAME):
             self._username = init_data[CONF_USERNAME]
             return self._username


### PR DESCRIPTION
Second follow-up from #42/#44, and unlike #45 this one is a live defect.

```python
-        init_data = self.context.init_data  # type: ignore[attr-defined]
+        init_data = self.init_data
```

`context` is a mapping — `MappingProxyType` on the base class, a plain dict in practice — so `self.context.init_data` does not read the flow's init data. It raises:

```
AttributeError: 'dict' object has no attribute 'init_data'
```

Home Assistant puts the value on the handler: `FlowHandler` declares `init_data: Any = None` (`data_entry_flow.py`), and `FlowManager.async_init` assigns `flow.init_data = data` before dispatching the first step. `self.init_data` is the supported way to read it.

**Reachability:** `_try_get_username` tries `self._username`, then the config entry's `entry_data`, then `init_data`, then `unique_id`. A normal reauth carries the username in the entry data and returns before this line, so this is a fallback path — but when it is reached it raises instead of recovering the username, which is the opposite of what the branch is for. `mypy` flagged it in #44 as `"ConfigFlowContext" has no attribute "init_data"`, and the ignore is removed with the fix.

The other `_try_get_username` ignore, the `[return-value]` one on `return None`, is untouched here: making that annotation honest cascades to two call sites and needs a decision about what reauth should do when no username can be found at all. Happy to open that separately, with a suggestion, if you want it dealt with.

## Verification

- `mypy custom_components/aquarea` → `Success: no issues found in 11 source files`
- `python3 tests/test_setup_entry_errors.py` and `python3 tests/test_zone_detector.py` → ALL PASSED
