### PR TITLE
Return None from from_dict when the restored payload is unusable

### DIFF
--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -198,9 +198,10 @@ class AquareaSensorExtraStoredData(SensorExtraStoredData):
     period_being_processed: datetime | None = None
 
     @classmethod
-    def from_dict(cls, restored: dict[str, Any]) -> Self:
-        # restored data may be None
-        sensor_data: Self = super().from_dict(restored)  # type: ignore[assignment]
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
+        sensor_data = super().from_dict(restored)
+        if sensor_data is None:
+            return None
         return cls(
             native_value=sensor_data.native_value,
             native_unit_of_measurement=sensor_data.native_unit_of_measurement,
@@ -218,8 +219,10 @@ class AquareaAccumulatedSensorExtraStoredData(AquareaSensorExtraStoredData):
     accumulated_period_being_processed: float | None = None
 
     @classmethod
-    def from_dict(cls, restored: dict[str, Any]) -> Self:
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
         sensor_data = super().from_dict(restored)
+        if sensor_data is None:
+            return None
         return cls(
             native_value=sensor_data.native_value,
             native_unit_of_measurement=sensor_data.native_unit_of_measurement,
@@ -462,9 +465,10 @@ class AquareaEdgeCounterExtraStoredData(SensorExtraStoredData):
     last_state: bool = False
 
     @classmethod
-    def from_dict(cls, restored: dict[str, Any]) -> Self:
-        # restored data may be None
-        sensor_data: Self = super().from_dict(restored)  # type: ignore[assignment]
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
+        sensor_data = super().from_dict(restored)
+        if sensor_data is None:
+            return None
         return cls(
             native_value=sensor_data.native_value,
             native_unit_of_measurement=sensor_data.native_unit_of_measurement,


### PR DESCRIPTION
Third follow-up from #42/#44, and the last reachable defect in that baseline.

Home Assistant's `SensorExtraStoredData.from_dict` returns `None` when the stored dict is missing a key it needs — an older payload written by a previous version of the integration, or a truncated one:

```python
try:
    native_value: StateType | date | datetime | Decimal = restored["native_value"]
    ...
except KeyError:
    return None
```

All three overrides here dereferenced that result immediately:

```python
        sensor_data = super().from_dict(restored)
        return cls(native_value=sensor_data.native_value, ...)
```

so restoring such a payload raises `AttributeError: 'NoneType' object has no attribute 'native_value'` out of `async_added_to_hass`, and the entity comes up unavailable rather than starting fresh.

## The change

Propagate the `None` and widen the overrides to `-> Self | None`, matching the base class signature.

Nothing downstream needs to change, which is what makes this safe: all three `async_get_last_sensor_data` overrides already declare `-> ... | None`, and their three callers (`AccumulatedEnergySensor`, `TodayEnergySensor`, `DailyEdgeCounterSensor`) already test `is not None` before using the result. The `None` simply reaches them by a path that no longer crashes on the way.

`AquareaAccumulatedSensorExtraStoredData.from_dict` gets the same guard although it had no error of its own — it calls `AquareaSensorExtraStoredData.from_dict`, whose return type this widens.

## Verification

- `mypy custom_components/aquarea` → `Success: no issues found in 11 source files`, two more ignores gone (10 left, all typing or dead-code cleanups)
- `python3 tests/test_setup_entry_errors.py`, `python3 tests/test_zone_detector.py` → ALL PASSED
