### PR TITLE
Abort reauth when no username can be determined

### DIFF
--- a/custom_components/aquarea/config_flow.py
+++ b/custom_components/aquarea/config_flow.py
@@ -87,21 +87,25 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, entry_data: Mapping[str, Any], user_input=None):
         """Perform reauth upon an API authentication error."""
-        self._username = self._try_get_username(entry_data)
+        username = self._try_get_username(entry_data)
+        if username is None:
+            # No username in the entry data, the flow context or the unique ID -
+            # nothing to reauthenticate against. Abort with a clear message
+            # instead of letting None reach the API client as invalid_auth.
+            return self.async_abort(reason="reauth_no_username")
+        self._username = username
         errors = {}
 
         if user_input is not None:
-            errors = await self._validate_input(
-                self._username, user_input[CONF_PASSWORD]
-            )
+            errors = await self._validate_input(username, user_input[CONF_PASSWORD])
 
             if not errors:
                 # If we get here, we have a valid login
                 return await self.async_complete_reauth(
-                    self._username, user_input[CONF_PASSWORD]
+                    username, user_input[CONF_PASSWORD]
                 )
 
-        return await self.async_show_reauth_form(self._username, errors)
+        return await self.async_show_reauth_form(username, errors)
 
     async def async_complete_reauth(self, username: str, password: str) -> ConfigFlowResult:
         """Complete reauth."""
@@ -128,8 +132,8 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    def _try_get_username(self, entry_data: Mapping[str, Any]) -> str:
-        """Try to get username from entry data or context"""
+    def _try_get_username(self, entry_data: Mapping[str, Any]) -> str | None:
+        """Try to get username from entry data or context, None if unknown."""
         if self._username is not None:
             return self._username
 
@@ -146,8 +150,8 @@ class AquareaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._username = self.unique_id
             return self._username
 
-        # returns None when no username is known
-        return None  # type: ignore[return-value]
+        # No username is known; async_step_reauth aborts on this.
+        return None
 
     async def _validate_input(self, username, password) -> dict[str, str]:
         """Validate the user input allows us to connect."""

--- a/custom_components/aquarea/strings.json
+++ b/custom_components/aquarea/strings.json
@@ -17,7 +17,8 @@
       "api_error": "API error: {api_error_msg}"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_no_username": "Could not reauthenticate: this configuration entry has no stored username. Remove the integration and add it again."
     }
   },
   "options": {

--- a/custom_components/aquarea/translations/en.json
+++ b/custom_components/aquarea/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_no_username": "Could not reauthenticate: this configuration entry has no stored username. Remove the integration and add it again."
         },
         "error": {
             "cannot_connect": "Failed to connect",

--- a/custom_components/aquarea/translations/pl.json
+++ b/custom_components/aquarea/translations/pl.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Urządzenie jest już skonfigurowane"
+            "already_configured": "Urządzenie jest już skonfigurowane",
+            "reauth_no_username": "Nie można ponownie uwierzytelnić: ten wpis konfiguracji nie ma zapisanej nazwy użytkownika. Usuń integrację i dodaj ją ponownie."
         },
         "error": {
             "cannot_connect": "Nie udało się połączyć",

--- a/tests/test_reauth_username.py
+++ b/tests/test_reauth_username.py
@@ -1,0 +1,188 @@
+"""Regression tests for reauth when no username can be determined.
+
+Background
+----------
+`_try_get_username` tries four sources in order - a cached `_username`, the
+config entry data, the flow handler's `init_data`, and finally the unique ID -
+and returns `None` when all four miss. It was annotated `-> str` with a
+`# type: ignore[return-value]` on that final `return None`.
+
+The caller, `async_step_reauth`, used the result unconditionally: `None` would
+flow into `aioaquarea.Client(session, None, password)` (surfacing as a
+misleading `invalid_auth`) and into the reauth form's
+`description_placeholders`. It only happens for a config entry that carries
+neither a username nor a username-shaped unique ID - plausible only for one
+written by a very old version - but the failure was confusing rather than
+clear.
+
+The fix: `_try_get_username` is now honestly typed `-> str | None`, and
+`async_step_reauth` aborts with `reauth_no_username` when it returns `None`.
+
+These tests load the *actual* `_try_get_username` and `async_step_reauth` out
+of config_flow.py (via AST, so they exercise the shipped code rather than a
+copy) and drive them with a stub flow handler.
+
+Intentionally dependency-free (stdlib only) so it runs without Home Assistant,
+aioaquarea, aiohttp or pytest installed:
+
+    python3 tests/test_reauth_username.py
+"""
+import ast
+import asyncio
+import os
+import sys
+
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
+
+CONFIG_FLOW = os.path.join(
+    os.path.dirname(__file__),
+    "..", "custom_components", "aquarea", "config_flow.py",
+)
+
+
+# --- pull the real methods out of config_flow.py --------------------------
+def _load_methods():
+    with open(CONFIG_FLOW, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read())
+    cls = next(
+        n for n in tree.body
+        if isinstance(n, ast.ClassDef) and n.name == "AquareaConfigFlow"
+    )
+    wanted = ("_try_get_username", "async_step_reauth")
+    nodes = {
+        n.name: n
+        for n in cls.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name in wanted
+    }
+    namespace = {
+        "CONF_USERNAME": CONF_USERNAME,
+        "CONF_PASSWORD": CONF_PASSWORD,
+    }
+    module = ast.Module([nodes[name] for name in wanted], [])
+    exec(compile(module, CONFIG_FLOW, "exec"), namespace)
+    return namespace["_try_get_username"], namespace["async_step_reauth"]
+
+
+_try_get_username, async_step_reauth = _load_methods()
+
+
+# --- fake flow handler ----------------------------------------------------
+class _Abort:
+    def __init__(self, reason):
+        self.type = "abort"
+        self.reason = reason
+
+
+class _Form:
+    def __init__(self, username, errors):
+        self.type = "form"
+        self.username = username
+        self.errors = errors
+
+
+class _FakeFlow:
+    """Stands in for AquareaConfigFlow with just what the two methods touch."""
+
+    def __init__(self, *, cached=None, init_data=None, unique_id=None):
+        self._username = cached
+        self.init_data = init_data
+        self.unique_id = unique_id
+        self._validated_with = None
+
+    # bound copies of the extracted methods
+    _try_get_username = _try_get_username
+    async_step_reauth = async_step_reauth
+
+    def async_abort(self, *, reason):
+        return _Abort(reason)
+
+    async def _validate_input(self, username, password):
+        self._validated_with = (username, password)
+        return {}
+
+    async def async_complete_reauth(self, username, password):
+        return ("complete", username, password)
+
+    async def async_show_reauth_form(self, username, errors=None):
+        return _Form(username, errors)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def main():
+    failures = 0
+
+    def check(name, ok, detail=""):
+        nonlocal failures
+        failures += not ok
+        print(f"[{'PASS' if ok else 'FAIL'}] {name:<58} {detail}")
+
+    # --- _try_get_username: source precedence ----------------------------
+    flow = _FakeFlow(cached="cached-user")
+    check(
+        "cached _username wins",
+        flow._try_get_username({CONF_USERNAME: "entry-user"}) == "cached-user",
+    )
+
+    flow = _FakeFlow()
+    check(
+        "entry data username used",
+        flow._try_get_username({CONF_USERNAME: "entry-user"}) == "entry-user",
+    )
+
+    flow = _FakeFlow(init_data={CONF_USERNAME: "init-user"})
+    check(
+        "init_data username used when entry data has none",
+        flow._try_get_username({}) == "init-user",
+    )
+
+    flow = _FakeFlow(unique_id="unique-user")
+    check(
+        "unique_id used as last resort",
+        flow._try_get_username({}) == "unique-user",
+    )
+
+    flow = _FakeFlow()
+    got = flow._try_get_username({})
+    check("returns None when every source misses", got is None, f"got={got!r}")
+
+    flow = _FakeFlow(unique_id=None)
+    got = flow._try_get_username(None)
+    check("entry_data=None is tolerated", got is None, f"got={got!r}")
+
+    # --- async_step_reauth: abort vs proceed ----------------------------
+    flow = _FakeFlow()
+    result = _run(flow.async_step_reauth({}))
+    check(
+        "reauth aborts with reauth_no_username when no username is known",
+        isinstance(result, _Abort) and result.reason == "reauth_no_username",
+        f"got={getattr(result, 'reason', result)!r}",
+    )
+
+    flow = _FakeFlow(unique_id="unique-user")
+    result = _run(flow.async_step_reauth({}))
+    check(
+        "reauth shows the form (not None) when a username is known",
+        isinstance(result, _Form) and result.username == "unique-user",
+        f"got={getattr(result, 'username', result)!r}",
+    )
+
+    flow = _FakeFlow(cached="cached-user")
+    result = _run(flow.async_step_reauth({}, {CONF_PASSWORD: "pw"}))
+    check(
+        "reauth validates with the resolved username, never None",
+        result == ("complete", "cached-user", "pw"),
+        f"got={result!r}",
+    )
+
+    print()
+    print("ALL PASSED" if not failures else f"{failures} FAILURE(S)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #48 — you picked **A** (abort with a clear error).

## Change

`_try_get_username` returns `None` when the config entry data, the flow
handler's `init_data` and the unique ID all lack a username. `async_step_reauth`
used that result unconditionally, so `None` reached
`aioaquarea.Client(session, None, password)` (surfacing as a misleading
`invalid_auth`) and went into the reauth form's `description_placeholders`.

- `_try_get_username` is now typed `-> str | None`, and the
  `# type: ignore[return-value]` on its final `return None` is gone.
- `async_step_reauth` takes the username into a local, and aborts with a new
  `reauth_no_username` reason when it is `None` — before any use. The three
  downstream calls now receive the narrowed `str`, so no `str | None` cascades
  to `async_complete_reauth` / `async_show_reauth_form`.
- New abort string added to `strings.json`, `translations/en.json` and
  `translations/pl.json`; the other seven languages fall back to English.

## Reachability

As noted in #48: this needs an entry with neither a stored `username` nor a
username-shaped `unique_id`, plausible only for one written by a much older
version. Not a bug seen in the wild — `mypy` flagged the annotation in #44 and
the honest fix needed your call on behaviour.

## Tests

`tests/test_reauth_username.py` — stdlib-only, AST-loads the real
`_try_get_username` and `async_step_reauth` from `config_flow.py` (same style as
`test_setup_entry_errors.py` / `test_zone_detector.py`). Covers the four-source
precedence, the `None` fallback, and the abort-vs-proceed branches in
`async_step_reauth`.

## Verification

- `mypy custom_components/aquarea` → `Success: no issues found in 11 source files`
  (HA 2026.9.1 / mypy 2.3.1 / Python 3.14)
- `python tests/test_reauth_username.py` → `ALL PASSED`
- `python tests/test_zone_detector.py`, `python tests/test_setup_entry_errors.py` → still `ALL PASSED`

## Remaining #44 baseline

After this, the baseline is the ~10 pure typing / dead-code ignores with no
runtime consequence (`select.py` `current_option` ×2, `water_heater.py`
`_attr_state` ×4, `coordinator.py` `DataUpdateCoordinator[None]`, the rest of
`config_flow.py`). Happy to send those as one batch PR whenever you want them
gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)